### PR TITLE
Update vintage_brush.js to use ordinal scale instead of linear

### DIFF
--- a/vintage/vintage_brush.js
+++ b/vintage/vintage_brush.js
@@ -106,11 +106,13 @@ var canvas = d3.select("body").append("svg")
 // Define our scales
 var colorScale = d3.scale.category20();
 
+var xMin = d3.min(data, function(d) { return d.year; }) - 1;
+var xMax =  d3.max(data, function(d) { return d.year; }) + 1 ;
+var xDomain = Array.from(new Array(xMax - xMin + 1), (x, i) => i + xMin);
 
-var x = d3.scale.linear()
-.domain([ d3.min(data, function(d) { return d.year; }) - 1,
-  d3.max(data, function(d) { return d.year; }) + 1 ])
-.range([0, width]);
+var x = d3.scale.scaleOrdinal()
+    .domain(xDomain )
+    .range([0, width]);
 
 var y = d3.scale.linear()
 .domain([ d3.min(data, function(d) { return d.uniscore; }) ,


### PR DESCRIPTION
Right now, the linear scaling allows non-year entities such as "1991.5"

This explicitly ties it to being integers. 

This does NOT use the time scale because we don't have the level of granularity of Months/Days

See
https://www.d3indepth.com/scales/#scales-with-discrete-input-and-discrete-output